### PR TITLE
Force misaka version to be below 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'click',
         'gevent',
         'jinja2',
-        'misaka',
+        'misaka<2',
         'pygments',
     ],
     entry_points='''


### PR DESCRIPTION
As it is right now, moo doesn't work on a fresh installation. You get this error when launching moo:
```
Traceback (most recent call last):
  File "/usr/local/bin/moo", line 7, in <module>
    from moo import main
  File "/usr/local/lib/python2.7/site-packages/moo/__init__.py", line 57, in <module>
    | misaka.EXT_TABLES
AttributeError: 'module' object has no attribute 'EXT_LAX_HTML_BLOCKS'
```

This is probably due to breaking changes inside misaka 2. Forcing the package to install a misaka package prior version 2 fix the problem.