### PR TITLE
BugFix: Listen only on localhost

### DIFF
--- a/moo/__init__.py
+++ b/moo/__init__.py
@@ -147,7 +147,7 @@ def preview(filename, options={}):
     def static(res):
         return static_file(res, root=dirpath)
 
-    server = WSGIServer(("0.0.0.0", options.get('port', 0)), app, log=None)
+    server = WSGIServer(("127.0.0.1", options.get('port', 0)), app, log=None)
     server.start()
 
     url = 'http://127.0.0.1:%d' % server.server_port


### PR DESCRIPTION
The output claims that the web server is listening on 127.0.0.1, which
would be relatively safe.

However, the code was actually listening on 0.0.0.0. This means that
the markdown preview was being broadcast to the the the local network
(or possibly the internet!) when it was intended to be local, allowing
others to see content that was intended to be private.